### PR TITLE
Make payroll project filter support multiple enrollments

### DIFF
--- a/payroll/services.py
+++ b/payroll/services.py
@@ -200,10 +200,10 @@ class PayrollService(BaseService):
         location_ids = filter_criteria.get("location_ids", [])
         if location_ids:
             beneficiaries_queryset = beneficiaries_queryset.filter(
-                Q(individual__location__uuid__in=location_ids) |
-                Q(individual__location__parent__uuid__in=location_ids) |
-                Q(individual__location__parent__parent__uuid__in=location_ids) |
-                Q(individual__location__parent__parent__parent__uuid__in=location_ids)
+                Q(individual__location__uuid__in=location_ids)
+                | Q(individual__location__parent__uuid__in=location_ids)
+                | Q(individual__location__parent__parent__uuid__in=location_ids)
+                | Q(individual__location__parent__parent__parent__uuid__in=location_ids)
             )
 
         custom_filters = [

--- a/payroll/services.py
+++ b/payroll/services.py
@@ -193,7 +193,8 @@ class PayrollService(BaseService):
         project_ids = filter_criteria.get("project_ids", [])
         if project_ids:
             beneficiaries_queryset = beneficiaries_queryset.filter(
-                project__id__in=project_ids
+                project_enrollments__project__id__in=project_ids,
+                project_enrollments__is_deleted=False
             )
 
         location_ids = filter_criteria.get("location_ids", [])

--- a/payroll/services.py
+++ b/payroll/services.py
@@ -218,7 +218,7 @@ class PayrollService(BaseService):
                 beneficiaries_queryset,
             )
 
-        return beneficiaries_queryset
+        return beneficiaries_queryset.distinct()
 
     def _generate_benefits(self, payment_plan, beneficiaries_queryset, date_from, date_to, payroll, payment_cycle):
         calculation = get_calculation_object(payment_plan.calculation)

--- a/payroll/tests/payroll_gql_tests.py
+++ b/payroll/tests/payroll_gql_tests.py
@@ -74,8 +74,15 @@ class PayrollGQLTestCase(openIMISGraphQLTestCase):
         cls.village = create_test_location("V", custom_props={"code": "VILL-PAYROLL-01", "parent": cls.ward})
         cls.other_location = create_test_location("V", custom_props={"code": "VILL-OTHER-01"})
 
-        cls.project_1 = create_project("Payroll Project 1", cls.benefit_plan, cls.user.username, status=ProjectStatus.COMPLETED)
-        cls.project_2 = create_project("Payroll Project 2", cls.benefit_plan, cls.user.username, status=ProjectStatus.COMPLETED)
+        cls.project_1 = create_project(
+            "Payroll Project 1", cls.benefit_plan, cls.user.username,
+            allows_multiple_enrollments=True, status=ProjectStatus.COMPLETED,
+        )
+        cls.project_2 = create_project(
+            "Payroll Project 2", cls.benefit_plan, cls.user.username,
+            allows_multiple_enrollments=True, status=ProjectStatus.COMPLETED,
+        )
+        # Both projects allow multiple enrollments to support test_create_with_multi_project_enrollment_no_duplicates
 
         cls.individual = cls.__create_individual(location=None, able_bodied=True)
         cls.individual_2 = cls.__create_individual(location=cls.village, able_bodied=False)
@@ -313,6 +320,50 @@ class PayrollGQLTestCase(openIMISGraphQLTestCase):
     def test_create_fail_due_to_empty_name(self):
         payroll = self.create_payroll("", self.json_ext_able_bodied_true)
         self.assertIsNone(payroll)
+
+    def test_create_with_multi_project_enrollment_no_duplicates(self):
+        """Regression test: beneficiary enrolled in multiple filtered projects should not be duplicated."""
+        # Create a beneficiary enrolled in BOTH project_1 AND project_2
+        multi_enrolled_individual = self.__create_individual(able_bodied=True)
+        multi_enrolled_beneficiary = Beneficiary(
+            individual=multi_enrolled_individual,
+            benefit_plan=self.benefit_plan,
+            json_ext=multi_enrolled_individual.json_ext,
+            status=BeneficiaryStatus.ACTIVE,
+        )
+        multi_enrolled_beneficiary.save(username=self.user.username)
+
+        enrollment_1 = BeneficiaryProjectEnrollment(
+            beneficiary=multi_enrolled_beneficiary,
+            project=self.project_1,
+        )
+        enrollment_1.save(username=self.user.username)
+        enrollment_2 = BeneficiaryProjectEnrollment(
+            beneficiary=multi_enrolled_beneficiary,
+            project=self.project_2,
+        )
+        enrollment_2.save(username=self.user.username)
+
+        # Filter by both projects - without distinct() this would duplicate the beneficiary
+        json_ext = json.dumps({
+            "filter_criteria": {
+                "project_ids": [str(self.project_1.id), str(self.project_2.id)]
+            }
+        })
+        payroll = self.create_payroll(f"{self.name}_multi_enroll", json_ext)
+        self.assertIsNotNone(payroll)
+
+        # Count benefits for the multi-enrolled beneficiary - should be exactly 1, not 2
+        payroll_benefits = PayrollBenefitConsumption.objects.filter(
+            payroll=payroll,
+            benefit__individual=multi_enrolled_individual,
+            is_deleted=False
+        )
+        self.assertEqual(
+            payroll_benefits.count(),
+            1,
+            "Beneficiary enrolled in multiple filtered projects should only generate one benefit"
+        )
 
     # def test_create_fail_due_to_one_bill_assigment(self):
     #     tmp_name = f"{self.name}-tmp"

--- a/payroll/tests/payroll_gql_tests.py
+++ b/payroll/tests/payroll_gql_tests.py
@@ -19,7 +19,7 @@ from core.test_helpers import LogInHelper, create_test_role
 from core.models.openimis_graphql_test_case import openIMISGraphQLTestCase, BaseTestContext
 from payroll.schema import Query, Mutation
 from location.test_helpers import create_test_location
-from social_protection.models import BenefitPlan, Beneficiary, BeneficiaryStatus, ProjectStatus
+from social_protection.models import BenefitPlan, Beneficiary, BeneficiaryStatus, BeneficiaryProjectEnrollment, ProjectStatus
 from social_protection.tests.data import service_add_payload
 from social_protection.tests.test_helpers import create_project
 from location.test_helpers import create_basic_test_locations
@@ -460,10 +460,13 @@ class PayrollGQLTestCase(openIMISGraphQLTestCase):
             "benefit_plan": cls.benefit_plan,
             "json_ext": individual.json_ext,
             "status": BeneficiaryStatus.ACTIVE,
-            "project": project
         }
         beneficiary = Beneficiary(**object_data)
         beneficiary.save(username=cls.user.username)
+
+        enrollment = BeneficiaryProjectEnrollment(beneficiary=beneficiary, project=project)
+        enrollment.save(username=cls.user.username)
+
         return beneficiary
 
     @classmethod


### PR DESCRIPTION
# Description

Since fixing the support for multiple project enrollment requires updating the beneficiary-project relationship to 1-M, the payroll filtering query needs to be updated as well. Depends on https://github.com/openimis/openimis-be-social_protection_py/pull/119

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [x] Requires [[link to github PR]](https://github.com/openimis/openimis-be-social_protection_py/pull/119)
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Checklist
- [x] Unit tests added/modified
- [ ] I18n / translation handled
